### PR TITLE
Fix logging when API key missing

### DIFF
--- a/autoload/ai_summary/api.vim
+++ b/autoload/ai_summary/api.vim
@@ -11,7 +11,8 @@ endfunction
 function! ai_summary#api#CallOpenAIAPI(tmpfile) abort
     let api_key = $OPENAI_API_KEY
     if empty(api_key)
-        call ai_summary#debug#Log("ERROR: OPENAI_API_KEY is empty!")
+        " Log the error to the dedicated error log file
+        call ai_summary#debug#ErrorLog("OPENAI_API_KEY is empty!")
         echom "ERROR: OPENAI_API_KEY is empty!"
         return ""
     endif


### PR DESCRIPTION
## Summary
- fix typo in error logging when `OPENAI_API_KEY` is not configured

## Testing
- `python3 -m py_compile glass_summary/*.py`

------
https://chatgpt.com/codex/tasks/task_e_685a4b55bc3083279127b69935c466a1